### PR TITLE
Added parenthesis in config.sample.php github configuration

### DIFF
--- a/usr/configuration/config.sample.php
+++ b/usr/configuration/config.sample.php
@@ -187,6 +187,7 @@
         'title' => 'Github',
         'description' => 'My recent activity',
         'method' => 'GithubRecentActivity'
+        )
     ); //*/
 
     /*


### PR DESCRIPTION
I believe a parenthesis is missing in the  sample config file, in the github configuration.
